### PR TITLE
docs: add security WG readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# litellm-security-wg
-LiteLLM Ecosystem Security Working Group
+# LiteLLM Security Working Group
+
+The LiteLLM Security WG is responsible for coordinating and improving security across the LiteLLM ecosystem.
+
+## Table of Contents
+
+- [Reporting Security Issues](#reporting-security-issues)
+- [Current Initiatives](#current-initiatives)
+- [Current Team Members](#current-team-members)
+- [Code of Conduct](#code-of-conduct)
+
+## Reporting Security Issues
+
+**Do not report security vulnerabilities via public GitHub issues.**
+
+Please report security issues to: **security@berriAI.com**
+
+You can also submit via [GitHub Security Advisories](https://github.com/BerriAI/litellm/security/advisories/new).
+
+We will acknowledge your report within 48 hours and aim to provide a fix within 90 days.
+
+## Current Initiatives
+
+| Initiative | Status |
+|---|---|
+| Supply chain security hardening | In Progress |
+| Security disclosure process | In Progress |
+| Dependency audit | TODO |
+
+## Current Team Members
+
+| GitHub | Name |
+|---|---|
+| [@ishaan-berri](https://github.com/ishaan-berri) | Ishaan |
+| [@krrish-berri-2](https://github.com/krrish-berri-2) | Krrish |
+
+## Code of Conduct
+
+This working group follows the [LiteLLM Code of Conduct](https://github.com/BerriAI/litellm/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Adds initial README for the LiteLLM Security Working Group with reporting instructions, current initiatives, and team members.